### PR TITLE
Add core pipeline classes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: Run tox
+        run: tox -e py$(echo ${{ matrix.python-version }} | tr -d '.')
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: Run linters
+        run: tox -e lint

--- a/.gitignore
+++ b/.gitignore
@@ -3,192 +3,26 @@ __pycache__/
 *.py[cod]
 *$py.class
 
-# C extensions
-*.so
-
 # Distribution / packaging
-.Python
 build/
-develop-eggs/
 dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-share/python-wheels/
 *.egg-info/
-.installed.cfg
-*.egg
-MANIFEST
+.eggs/
 
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.nox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-*.py,cover
-.hypothesis/
-.pytest_cache/
-cover/
-
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-.pybuilder/
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# IPython
-profile_default/
-ipython_config.py
-
-# pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
-# .python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# UV
-#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#uv.lock
-
-# poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
-
-# pdm
-#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
-#pdm.lock
-#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
-#   in version control.
-#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
-.pdm.toml
-.pdm-python
-.pdm-build/
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
-__pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
-
-# Environments
-.env
-.venv
-env/
+# Virtual environments
 venv/
-ENV/
-env.bak/
-venv.bak/
+.env
+.env/
 
-# Spyder project settings
-.spyderproject
-.spyproject
+# Pytest cache
+.pytest_cache/
 
-# Rope project settings
-.ropeproject
+# Coverage reports
+htmlcov/
+.coverage
 
-# mkdocs documentation
-/site
-
-# mypy
+# MyPy
 .mypy_cache/
-.dmypy.json
-dmypy.json
 
-# Pyre type checker
-.pyre/
-
-# pytype static type analyzer
-.pytype/
-
-# Cython debug symbols
-cython_debug/
-
-# PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
-
-# Abstra
-# Abstra is an AI-powered process automation framework.
-# Ignore directories containing user credentials, local state, and settings.
-# Learn more at https://abstra.io/docs
-.abstra/
-
-# Visual Studio Code
-#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
-#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
-#  you could uncomment the following to ignore the enitre vscode folder
-# .vscode/
-
-# Ruff stuff:
-.ruff_cache/
-
-# PyPI configuration file
-.pypirc
-
-# Cursor
-#  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
-#  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
-#  refer to https://docs.cursor.com/context/ignore-files
-.cursorignore
-.cursorindexingignore
+# VSCode settings
+.vscode/

--- a/README.md
+++ b/README.md
@@ -69,3 +69,13 @@ result = pipe.run()
 
 **Community & Contributions**
 data-transformer-pipe is open-source under the MIT license. Contributions are welcome—whether to add new operators, improve documentation, or enhance core features. Visit the GitHub repository `data-transformer-pipe` to file issues, submit pull requests, or join discussions.
+
+## Development
+
+This project uses [tox](https://tox.wiki) to manage testing and linting. To run
+all checks locally, install `tox` and run:
+
+```bash
+pip install tox
+tox
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "data-transformer-pipe"
+version = "0.1.0"
+description = "A declarative, pandas-based ETL library"
+authors = [
+    { name="Your Name", email="you@example.com" }
+]
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.8"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+
+[project.urls]
+Homepage = "https://github.com/yourname/data-transformer-pipe"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-ra -q"
+
+[tool.black]
+line-length = 88
+
+[tool.flake8]
+max-line-length = 88
+extend-ignore = ["E203", "W503"]
+
+[tool.isort]
+profile = "black"

--- a/src/data_transformer_pipe/__init__.py
+++ b/src/data_transformer_pipe/__init__.py
@@ -1,0 +1,12 @@
+"""data-transformer-pipe library."""
+
+from .transformer import DataTransformer
+from .pipe import ProcessPipe, Operator, JoinOperator, UnionOperator
+
+__all__ = [
+    "DataTransformer",
+    "ProcessPipe",
+    "Operator",
+    "JoinOperator",
+    "UnionOperator",
+]

--- a/src/data_transformer_pipe/pipe.py
+++ b/src/data_transformer_pipe/pipe.py
@@ -1,0 +1,130 @@
+"""Core pipeline classes for data-transformer-pipe."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Union
+
+import pandas as pd
+
+
+@dataclass
+class Operator:
+    """Base class for all operations."""
+
+    output: str
+
+    def execute(self, env: Dict[str, pd.DataFrame]) -> pd.DataFrame:
+        raise NotImplementedError
+
+
+@dataclass
+class JoinOperator(Operator):
+    left: str
+    right: str
+    on: Union[str, List[str]]
+    how: str = "left"
+
+    def execute(self, env: Dict[str, pd.DataFrame]) -> pd.DataFrame:
+        if self.left not in env or self.right not in env:
+            raise KeyError(f"[JoinOperator] missing table: {self.left} or {self.right}")
+        df_l = env[self.left]
+        df_r = env[self.right]
+        result = df_l.merge(df_r, how=self.how, on=self.on)
+        print(
+            f"[JoinOperator] {self.left} {self.how} join {self.right} on {self.on} -> "
+            f"'{self.output}' shape={result.shape}"
+        )
+        return result
+
+
+@dataclass
+class UnionOperator(Operator):
+    left: str
+    right: str
+
+    def execute(self, env: Dict[str, pd.DataFrame]) -> pd.DataFrame:
+        if self.left not in env or self.right not in env:
+            raise KeyError(
+                f"[UnionOperator] missing table: {self.left} or {self.right}"
+            )
+        df_l = env[self.left]
+        df_r = env[self.right]
+        result = pd.concat([df_l, df_r], ignore_index=True)
+        print(
+            f"[UnionOperator] concat {self.left} + {self.right} -> "
+            f"'{self.output}' shape={result.shape}"
+        )
+        return result
+
+
+class ProcessPipe:
+    """Manage DataFrame environment and operator execution."""
+
+    def __init__(self) -> None:
+        self.env: Dict[str, pd.DataFrame] = {}
+        self.operators: List[Operator] = []
+
+    def add_dataframe(self, name: str, df: pd.DataFrame) -> "ProcessPipe":
+        self.env[name] = df
+        return self
+
+    def join(
+        self,
+        left: str,
+        right: str,
+        on: Union[str, List[str]],
+        how: str = "left",
+        output: str | None = None,
+    ) -> "ProcessPipe":
+        if output is None:
+            output = f"{left}_{how}_join_{right}"
+        self.operators.append(
+            JoinOperator(output=output, left=left, right=right, on=on, how=how)
+        )
+        return self
+
+    def union(self, left: str, right: str, output: str | None = None) -> "ProcessPipe":
+        if output is None:
+            output = f"{left}_union_{right}"
+        self.operators.append(UnionOperator(output=output, left=left, right=right))
+        return self
+
+    def run(self) -> pd.DataFrame:
+        if not self.operators:
+            raise ValueError("ProcessPipe has no operators to execute")
+        result = None
+        for op in self.operators:
+            result = op.execute(self.env)
+            self.env[op.output] = result
+        assert result is not None
+        return result
+
+    @classmethod
+    def build_pipe(cls, pipeline_plan: Dict[str, Any]) -> "ProcessPipe":
+        pipe = cls()
+
+        for name, df in pipeline_plan.get("dataframes", {}).items():
+            if not isinstance(df, pd.DataFrame):
+                raise TypeError(f"dataframes['{name}'] is not a pandas DataFrame")
+            pipe.add_dataframe(name, df)
+
+        for op in pipeline_plan.get("operations", []):
+            op_type = op.get("type")
+            if op_type == "join":
+                pipe.join(
+                    left=op["left"],
+                    right=op["right"],
+                    on=op["on"],
+                    how=op.get("how", "left"),
+                    output=op.get("output"),
+                )
+            elif op_type == "union":
+                pipe.union(left=op["left"], right=op["right"], output=op.get("output"))
+            else:
+                raise ValueError(f"Unsupported operation type: {op_type}")
+
+        return pipe
+
+
+__all__ = ["ProcessPipe", "Operator", "JoinOperator", "UnionOperator"]

--- a/src/data_transformer_pipe/transformer.py
+++ b/src/data_transformer_pipe/transformer.py
@@ -1,0 +1,6 @@
+class DataTransformer:
+    """Example data transformer."""
+
+    def transform(self, data):
+        """Return the data unchanged."""
+        return data

--- a/tests/test_process_pipe.py
+++ b/tests/test_process_pipe.py
@@ -1,0 +1,37 @@
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+from data_transformer_pipe.pipe import ProcessPipe
+
+
+def test_join_and_union():
+    df1 = pd.DataFrame({"id": [1, 2, 3], "name": ["A", "B", "C"]})
+    df2 = pd.DataFrame({"id": [2, 3, 4], "score": [80, 90, 85]})
+    df3 = pd.DataFrame({"id": [5], "name": ["D"], "score": [75]})
+
+    plan = {
+        "dataframes": {"df1": df1, "df2": df2, "df3": df3},
+        "operations": [
+            {
+                "type": "join",
+                "left": "df1",
+                "right": "df2",
+                "on": "id",
+                "output": "joined",
+            },
+            {"type": "union", "left": "joined", "right": "df3", "output": "final"},
+        ],
+    }
+
+    pipe = ProcessPipe.build_pipe(plan)
+    result = pipe.run()
+
+    expected = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 5],
+            "name": ["A", "B", "C", "D"],
+            "score": [pd.NA, 80, 90, 75],
+        }
+    )
+
+    assert_frame_equal(result.reset_index(drop=True), expected)

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -1,0 +1,7 @@
+from data_transformer_pipe.transformer import DataTransformer
+
+
+def test_transformer_returns_input():
+    transformer = DataTransformer()
+    data = {"key": "value"}
+    assert transformer.transform(data) == data

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+envlist = py38, py39, py310, lint
+isolated_build = True
+
+[testenv]
+deps =
+    pytest
+commands =
+    pytest
+
+[testenv:lint]
+skip_install = true
+deps =
+    black
+    flake8
+    isort
+commands =
+    black --check src tests
+    flake8 src tests
+    isort --check-only src tests


### PR DESCRIPTION
## Summary
- implement `ProcessPipe` with join and union operators
- expose new classes in package `__init__`
- add unit test for pipeline execution

## Testing
- `black --check src tests`
- `PYTHONPATH=src python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684c3c5431008322bf012c6a4da114f5