### PR TITLE
Add CLI entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,42 @@ pipe.describe("pipeline_diagram")  # Generates pipeline_diagram.png
 result = pipe.run()
 ```
 
+**Quick Start (CLI)**
+After installing the package, you can run a pipeline directly from the command line.
+
+1. Create input CSV files `df1.csv` and `df2.csv`:
+
+   ```csv
+   # df1.csv
+   id,name
+   1,A
+   2,B
+   ```
+
+   ```csv
+   # df2.csv
+   id,score
+   1,10
+   2,20
+   ```
+
+2. Write a `plan.json` describing the pipeline:
+
+   ```json
+   {
+     "dataframes": {"df1": "df1.csv", "df2": "df2.csv"},
+     "operations": [{"type": "join", "left": "df1", "right": "df2", "on": "id"}]
+   }
+   ```
+
+3. Execute the plan and save the result:
+
+   ```bash
+   data-transformer-pipe plan.json -o result.csv
+   ```
+
+   The resulting `result.csv` will contain the joined rows.
+
 **Community & Contributions**
 data-transformer-pipe is open-source under the MIT license. Contributions are welcome—whether to add new operators, improve documentation, or enhance core features. Visit the GitHub repository `data-transformer-pipe` to file issues, submit pull requests, or join discussions.
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,36 @@ After installing the package, you can run a pipeline directly from the command l
 
    The resulting `result.csv` will contain the joined rows.
 
+**Additional Examples**
+
+You can build more complex plans or run them directly from Python.
+
+1. **Union Example**
+
+   ```python
+   import pandas as pd
+   from data_transformer_pipe import ProcessPipe
+
+   df1 = pd.DataFrame({"id": [1, 2], "value": [10, 20]})
+   df2 = pd.DataFrame({"id": [3], "value": [30]})
+
+   pipe = ProcessPipe().add_dataframe("a", df1).add_dataframe("b", df2)
+   pipe.union("a", "b", output="all")
+   result = pipe.run()
+   print(result._rows)
+   ```
+
+2. **Quick Analysis**
+
+   After a pipeline runs you have a normal pandas DataFrame. You can
+   perform any analysis you like, for example calculating averages:
+
+   ```python
+   values = [int(r["value"]) for r in result._rows]
+   avg_value = sum(values) / len(values)
+   print("Average:", avg_value)
+   ```
+
 **Community & Contributions**
 data-transformer-pipe is open-source under the MIT license. Contributions are welcome—whether to add new operators, improve documentation, or enhance core features. Visit the GitHub repository `data-transformer-pipe` to file issues, submit pull requests, or join discussions.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/yourname/data-transformer-pipe"
 
+[project.scripts]
+data-transformer-pipe = "data_transformer_pipe.__main__:main"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/src/data_transformer_pipe/__init__.py
+++ b/src/data_transformer_pipe/__init__.py
@@ -1,7 +1,7 @@
 """data-transformer-pipe library."""
 
+from .pipe import JoinOperator, Operator, ProcessPipe, UnionOperator
 from .transformer import DataTransformer
-from .pipe import ProcessPipe, Operator, JoinOperator, UnionOperator
 
 __all__ = [
     "DataTransformer",

--- a/src/data_transformer_pipe/__main__.py
+++ b/src/data_transformer_pipe/__main__.py
@@ -1,0 +1,59 @@
+import argparse
+import csv
+import json
+from typing import Dict
+
+import pandas as pd
+
+from .pipe import ProcessPipe
+
+
+def _load_csv(path: str) -> pd.DataFrame:
+    """Load a CSV file into the minimal pandas DataFrame."""
+    data: Dict[str, list] = {}
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            for key, value in row.items():
+                data.setdefault(key, []).append(value)
+    return pd.DataFrame(data)
+
+
+def _write_csv(df: pd.DataFrame, path: str) -> None:
+    with open(path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(df.columns)
+        for row in df._rows:  # type: ignore[attr-defined]
+            writer.writerow([row.get(col) for col in df.columns])
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Execute a data-transformer-pipe pipeline"
+    )
+    parser.add_argument("plan", help="JSON file describing the pipeline")
+    parser.add_argument("--output", "-o", help="Output CSV file path", default=None)
+    args = parser.parse_args(argv)
+
+    with open(args.plan) as f:
+        plan = json.load(f)
+
+    dataframes = plan.get("dataframes", {})
+    loaded = {}
+    for name, path in dataframes.items():
+        if not isinstance(path, str):
+            raise ValueError("DataFrame paths must be strings")
+        loaded[name] = _load_csv(path)
+    plan["dataframes"] = loaded
+
+    pipe = ProcessPipe.build_pipe(plan)
+    result = pipe.run()
+
+    if args.output:
+        _write_csv(result, args.output)
+    else:
+        print(result._rows)  # type: ignore[attr-defined]
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data_transformer_pipe/__main__.py
+++ b/src/data_transformer_pipe/__main__.py
@@ -32,7 +32,12 @@ def main(argv: list[str] | None = None) -> None:
         description="Execute a data-transformer-pipe pipeline"
     )
     parser.add_argument("plan", help="JSON file describing the pipeline")
-    parser.add_argument("--output", "-o", help="Output CSV file path", default=None)
+    parser.add_argument(
+        "--output",
+        "-o",
+        help="Output CSV file path",
+        default=None,
+    )
     args = parser.parse_args(argv)
 
     with open(args.plan) as f:

--- a/src/data_transformer_pipe/pipe.py
+++ b/src/data_transformer_pipe/pipe.py
@@ -27,7 +27,9 @@ class JoinOperator(Operator):
 
     def execute(self, env: Dict[str, pd.DataFrame]) -> pd.DataFrame:
         if self.left not in env or self.right not in env:
-            raise KeyError(f"[JoinOperator] missing table: {self.left} or {self.right}")
+            raise KeyError(
+                "[JoinOperator] missing table: " f"{self.left} or {self.right}"
+            )
         df_l = env[self.left]
         df_r = env[self.right]
         result = df_l.merge(df_r, how=self.how, on=self.on)
@@ -84,10 +86,16 @@ class ProcessPipe:
         )
         return self
 
-    def union(self, left: str, right: str, output: str | None = None) -> "ProcessPipe":
+    def union(
+        self,
+        left: str,
+        right: str,
+        output: str | None = None,
+    ) -> "ProcessPipe":
         if output is None:
             output = f"{left}_union_{right}"
-        self.operators.append(UnionOperator(output=output, left=left, right=right))
+        op = UnionOperator(output=output, left=left, right=right)
+        self.operators.append(op)
         return self
 
     def run(self) -> pd.DataFrame:
@@ -106,7 +114,8 @@ class ProcessPipe:
 
         for name, df in pipeline_plan.get("dataframes", {}).items():
             if not isinstance(df, pd.DataFrame):
-                raise TypeError(f"dataframes['{name}'] is not a pandas DataFrame")
+                msg = f"dataframes['{name}'] is not a pandas DataFrame"
+                raise TypeError(msg)
             pipe.add_dataframe(name, df)
 
         for op in pipeline_plan.get("operations", []):
@@ -120,7 +129,11 @@ class ProcessPipe:
                     output=op.get("output"),
                 )
             elif op_type == "union":
-                pipe.union(left=op["left"], right=op["right"], output=op.get("output"))
+                pipe.union(
+                    left=op["left"],
+                    right=op["right"],
+                    output=op.get("output"),
+                )
             else:
                 raise ValueError(f"Unsupported operation type: {op_type}")
 

--- a/src/pandas/__init__.py
+++ b/src/pandas/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from types import ModuleType
 from typing import Any, Dict, Iterable, List, Sequence
+import sys
 
 NA = None
 
@@ -44,7 +45,10 @@ class DataFrame:
         return (len(self._rows), len(self._rows[0]))
 
     def merge(
-        self, right: "DataFrame", how: str = "left", on: str | List[str] | None = None
+        self,
+        right: "DataFrame",
+        how: str = "left",
+        on: str | List[str] | None = None,
     ) -> "DataFrame":
         if how != "left":
             raise NotImplementedError("Only left join supported in stub")
@@ -56,10 +60,10 @@ class DataFrame:
             key = tuple(r.get(c) for c in on_cols)
             right_index[key] = r
         rows = []
-        for l in self._rows:
-            key = tuple(l.get(c) for c in on_cols)
+        for left_row in self._rows:
+            key = tuple(left_row.get(c) for c in on_cols)
             r = right_index.get(key)
-            new_row = l.copy()
+            new_row = left_row.copy()
             if r:
                 for c, v in r.items():
                     if c not in on_cols:
@@ -87,12 +91,11 @@ def concat(dfs: Iterable[DataFrame], ignore_index: bool = False) -> DataFrame:
 
 def assert_frame_equal(left: DataFrame, right: DataFrame) -> None:
     if left != right:
-        raise AssertionError(f"DataFrames not equal:\n{left._rows!r}\n{right._rows!r}")
+        message = f"DataFrames not equal:\n{left._rows!r}\n{right._rows!r}"
+        raise AssertionError(message)
 
 
 testing = ModuleType("pandas.testing")
 testing.assert_frame_equal = assert_frame_equal
-
-import sys
 
 sys.modules[__name__ + ".testing"] = testing

--- a/src/pandas/__init__.py
+++ b/src/pandas/__init__.py
@@ -1,10 +1,11 @@
 """Minimal pandas stub for testing without external dependency."""
 
 from __future__ import annotations
+
+import sys
 from dataclasses import dataclass
 from types import ModuleType
 from typing import Any, Dict, Iterable, List, Sequence
-import sys
 
 NA = None
 

--- a/tests/test_process_pipe.py
+++ b/tests/test_process_pipe.py
@@ -1,7 +1,6 @@
 import pandas as pd
-from pandas.testing import assert_frame_equal
-
 from data_transformer_pipe.pipe import ProcessPipe
+from pandas.testing import assert_frame_equal
 
 
 def test_join_and_union():


### PR DESCRIPTION
## Summary
- add a `__main__` module with a simple CLI for executing pipeline plans
- expose the console entry point in `pyproject.toml`

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c471666388322b6cd24ac4240058d