### PR TITLE
Add join/union example

### DIFF
--- a/examples/join_union_example.py
+++ b/examples/join_union_example.py
@@ -1,0 +1,43 @@
+import pandas as pd
+from data_transformer_pipe import ProcessPipe
+
+
+def main() -> None:
+    """Demonstrate join and union operations with simple analysis."""
+    # Initial DataFrames
+    customers = pd.DataFrame({
+        "id": [1, 2, 3],
+        "name": ["Alice", "Bob", "Charlie"],
+    })
+
+    scores = pd.DataFrame({
+        "id": [1, 2, 4],
+        "score": [85, 92, 88],
+    })
+
+    extra = pd.DataFrame({
+        "id": [5],
+        "name": ["Daisy"],
+        "score": [90],
+    })
+
+    # Build and run the pipeline
+    pipe = (
+        ProcessPipe()
+        .add_dataframe("customers", customers)
+        .add_dataframe("scores", scores)
+        .add_dataframe("extra", extra)
+        .join("customers", "scores", on="id", how="left", output="customer_scores")
+        .union("customer_scores", "extra", output="all_scores")
+    )
+
+    result = pipe.run()
+    print("Pipeline result:\n", result, "\n")
+
+    # Simple analysis: average score, ignoring missing values
+    avg_score = result["score"].astype(float).mean()
+    print("Average score:", avg_score)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_process_pipe_additional.py
+++ b/tests/test_process_pipe_additional.py
@@ -1,8 +1,8 @@
 import pytest
-import pandas as pd
-from pandas.testing import assert_frame_equal
 
+import pandas as pd
 from data_transformer_pipe.pipe import ProcessPipe
+from pandas.testing import assert_frame_equal
 
 
 def test_run_without_operators():


### PR DESCRIPTION
## Summary
- provide an end-to-end join & union pipeline example under `examples/`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684c74c7c87c8322946a934f63e24cff