### PR TITLE
Add DAG support and plan loader

### DIFF
--- a/processpipe/src/processpipe/__init__.py
+++ b/processpipe/src/processpipe/__init__.py
@@ -1,7 +1,12 @@
 from .core.pipe import ProcessPipe
+from .core.sql import sql_query
+from .plans.loader import load_plan
 from .operators import (
-    JoinOperator, UnionOperator, AggregationOperator,
-    GroupSizeOperator, FilterOperator,
+    JoinOperator,
+    UnionOperator,
+    AggregationOperator,
+    GroupSizeOperator,
+    FilterOperator,
 )
 
 __all__ = [
@@ -11,4 +16,6 @@ __all__ = [
     "AggregationOperator",
     "GroupSizeOperator",
     "FilterOperator",
+    "load_plan",
+    "sql_query",
 ]

--- a/processpipe/src/processpipe/core/pipe.py
+++ b/processpipe/src/processpipe/core/pipe.py
@@ -1,10 +1,21 @@
 from __future__ import annotations
+
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from typing import Dict
+
 import logging
+import json
 import pandas as pd
+import networkx as nx
+
 from ..operators import (
-    JoinOperator, UnionOperator, AggregationOperator,
-    GroupSizeOperator, FilterOperator, Operator,
+    JoinOperator,
+    UnionOperator,
+    AggregationOperator,
+    GroupSizeOperator,
+    FilterOperator,
+    Operator,
 )
 from .backend import FrameBackend, InMemoryBackend
 
@@ -16,12 +27,20 @@ if not log.handlers:
 
 
 class ProcessPipe:
-    """Fluent, in-memory pipeline executor."""
+    """Fluent, in-memory pipeline executor with a DAG."""
 
-    def __init__(self, backend: FrameBackend | None = None):
+    def __init__(
+        self,
+        backend: FrameBackend | None = None,
+        spill_enabled: bool = False,
+        max_workers: int = 1,
+    ) -> None:
         self.backend = backend or InMemoryBackend()
+        self.spill_enabled = spill_enabled
+        self.max_workers = max_workers
         self.env: Dict[str, pd.DataFrame] = {}
         self.ops: list[Operator] = []
+        self.dag = nx.DiGraph()
         self._last_output: str | None = None
 
     # ── data sources ──────────────────────────────────────────────
@@ -29,6 +48,7 @@ class ProcessPipe:
         if name in self.env:
             raise ValueError(f"DataFrame name '{name}' already exists.")
         self.env[name] = df
+        self.dag.add_node(name)
         return self
 
     # ── fluent operator helpers ───────────────────────────────────
@@ -53,6 +73,9 @@ class ProcessPipe:
     # internal
     def _append(self, op: Operator) -> "ProcessPipe":
         self.ops.append(op)
+        self.dag.add_node(op.output, operator=op)
+        for inp in op.inputs:
+            self.dag.add_edge(inp, op.output)
         self._last_output = op.output
         return self
 
@@ -60,7 +83,46 @@ class ProcessPipe:
     def run(self) -> pd.DataFrame:
         if not self.ops:
             raise ValueError("No operators defined.")
-        for op in self.ops:
-            res = op.execute(self.backend, self.env)
-            self.env[op.output] = res
+        # assign a level (depth) to each node so that operators with the same
+        # dependency depth can run concurrently
+        levels: Dict[str, int] = {}
+        for node in nx.topological_sort(self.dag):
+            preds = list(self.dag.predecessors(node))
+            lvl = 0
+            if preds:
+                lvl = max(levels[p] for p in preds) + 1
+            levels[node] = lvl
+
+        level_ops: Dict[int, list[Operator]] = defaultdict(list)
+        for node, lvl in levels.items():
+            op = self.dag.nodes[node].get("operator")
+            if op is not None:
+                level_ops[lvl].append(op)
+
+        for lvl in sorted(level_ops):
+            ops = level_ops[lvl]
+            if self.max_workers > 1 and len(ops) > 1:
+                with ThreadPoolExecutor(max_workers=self.max_workers) as ex:
+                    futures = {ex.submit(op.execute, self.backend, self.env): op for op in ops}
+                    for fut, op in futures.items():
+                        res = fut.result()
+                        self.env[op.output] = res
+            else:
+                for op in ops:
+                    res = op.execute(self.backend, self.env)
+                    self.env[op.output] = res
+
+        if self.max_workers > 1 or not isinstance(self.backend, InMemoryBackend):
+            lineage = [
+                {"operator": op.__class__.__name__, "output": op.output, "inputs": op.inputs}
+                for op in self.ops
+            ]
+            with open("pipeline_run.json", "w") as f:
+                json.dump({"max_workers": self.max_workers, "lineage": lineage}, f)
+
         return self.env[self._last_output]
+
+    def describe(self) -> None:
+        """Print the execution order of operators."""
+        for op in self.ops:
+            print(f"{op.__class__.__name__} -> '{op.output}'")

--- a/processpipe/src/processpipe/core/sql.py
+++ b/processpipe/src/processpipe/core/sql.py
@@ -1,0 +1,15 @@
+"""Optional pandasql wrapper used by ProcessPipe."""
+from __future__ import annotations
+import pandas as pd
+
+try:
+    from pandasql import sqldf
+except Exception:  # noqa: BLE001
+    sqldf = None
+
+
+def sql_query(df: pd.DataFrame, query: str) -> pd.DataFrame:
+    """Run an SQL query using pandasql if available."""
+    if sqldf is None:
+        raise ImportError("pandasql is required for SQL queries")
+    return sqldf(query, {"df": df})

--- a/processpipe/src/processpipe/plans/loader.py
+++ b/processpipe/src/processpipe/plans/loader.py
@@ -1,0 +1,46 @@
+import json
+from pathlib import Path
+from typing import Any
+import pandas as pd
+from ..core.pipe import ProcessPipe
+
+try:
+    import yaml  # type: ignore
+except Exception:  # noqa: BLE001
+    yaml = None
+
+def load_plan(path: str | Path) -> ProcessPipe:
+    """Load a YAML or JSON plan and build a :class:`ProcessPipe`."""
+    file_path = Path(path)
+    with open(file_path) as f:
+        if file_path.suffix in {".yml", ".yaml"}:
+            if yaml is None:
+                raise ImportError("PyYAML is required for YAML plans")
+            plan = yaml.safe_load(f)
+        else:
+            plan = json.load(f)
+
+    pipe = ProcessPipe()
+    for name, df_obj in plan.get("dataframes", {}).items():
+        if isinstance(df_obj, pd.DataFrame):
+            df = df_obj
+        else:
+            df = pd.DataFrame(df_obj)
+        pipe.add_dataframe(name, df)
+
+    for op in plan.get("operations", []):
+        op_type = op.get("type")
+        if op_type == "join":
+            pipe.join(op["left"], op["right"], on=op["on"], how=op.get("how", "left"), output=op.get("output"))
+        elif op_type == "union":
+            pipe.union(op["left"], op["right"], output=op.get("output"))
+        elif op_type == "aggregate":
+            pipe.aggregate(op["source"], groupby=op["groupby"], agg_map=op["agg_map"], output=op.get("output"))
+        elif op_type == "group_size":
+            pipe.group_size(op["source"], groupby=op["groupby"], output=op.get("output"))
+        elif op_type == "filter":
+            pipe.filter(op["source"], predicate=op["predicate"], output=op.get("output"))
+        else:
+            raise ValueError(f"Unsupported operation type: {op_type}")
+
+    return pipe

--- a/tests_processpipe/test_loader.py
+++ b/tests_processpipe/test_loader.py
@@ -1,0 +1,23 @@
+import pandas as pd
+from processpipe import load_plan
+
+
+def test_load_plan_json():
+    plan = {
+        "dataframes": {
+            "df1": {"id": [1, 2], "v": [10, 20]},
+            "df2": {"id": [2], "v2": [30]},
+        },
+        "operations": [
+            {"type": "join", "left": "df1", "right": "df2", "on": "id", "how": "left", "output": "j"},
+            {"type": "filter", "source": "j", "predicate": "v2 > 25", "output": "f"},
+        ],
+    }
+    import json, tempfile
+    with tempfile.NamedTemporaryFile("w+", suffix=".json", delete=False) as f:
+        json.dump(plan, f)
+        f.flush()
+        pipe = load_plan(f.name)
+    result = pipe.run()
+    assert isinstance(result, pd.DataFrame)
+    assert list(result.columns) == ["id", "v", "v2"]


### PR DESCRIPTION
## Summary
- make ProcessPipe maintain a networkx DAG of operator dependencies
- support loading plans from JSON or YAML files
- provide optional SQL facade via pandasql
- allow concurrent execution with `max_workers`
- write a `pipeline_run.json` lineage file when concurrency or a custom backend is used
- add tests for new loader module

## Testing
- `black --check -q .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685367acbec483229454f4da68c27241