### PR TITLE
Add mypy to linting and tox config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,5 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install tox
-      - name: Run linters
+      - name: Run linters and type checks
         run: tox -e lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,3 +41,9 @@ extend-ignore = ["E203", "W503"]
 
 [tool.isort]
 profile = "black"
+
+[tool.mypy]
+python_version = "3.10"
+check_untyped_defs = true
+disallow_incomplete_defs = true
+ignore_missing_imports = true

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,8 @@ isolated_build = True
 [testenv]
 deps =
     pytest
+setenv =
+    PYTHONPATH = {toxinidir}/src
 commands =
     pytest
 
@@ -14,7 +16,9 @@ deps =
     black
     flake8
     isort
+    mypy
 commands =
     black --check src tests
     flake8 src tests
     isort --check-only src tests
+    mypy src tests


### PR DESCRIPTION
## Summary
- configure tox to set `PYTHONPATH` for running tests
- add mypy to lint environment
- provide mypy configuration
- update CI job description

## Testing
- `PYTHONPATH=src python -m pytest -q`
- ❌ `python -m flake8 --version` *(fails: No module named flake8)*

------
https://chatgpt.com/codex/tasks/task_e_68537690eaf08322bfa3ae369a723cb6