### PR TITLE
Add setup.cfg with lint configs and update pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,22 +28,3 @@ data-transformer-pipe = "data_transformer_pipe.__main__:main"
 [tool.setuptools.packages.find]
 where = ["src", "processpipe"]
 
-[tool.pytest.ini_options]
-minversion = "6.0"
-addopts = "-ra -q"
-
-[tool.black]
-line-length = 88
-
-[tool.flake8]
-max-line-length = 88
-extend-ignore = ["E203", "W503"]
-
-[tool.isort]
-profile = "black"
-
-[tool.mypy]
-python_version = "3.10"
-check_untyped_defs = true
-disallow_incomplete_defs = true
-ignore_missing_imports = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,19 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203,W503
+
+[mypy]
+python_version = 3.10
+check_untyped_defs = true
+disallow_incomplete_defs = true
+ignore_missing_imports = true
+
+[tool:pytest]
+minversion = 6.0
+addopts = -ra -q
+
+[isort]
+profile = black
+
+[black]
+line-length = 88


### PR DESCRIPTION
## Summary
- provide lint and testing config in `setup.cfg`
- remove flake8, mypy, pytest options from `pyproject.toml`

## Testing
- `PYTHONPATH=src mypy src tests`
- `PYTHONPATH=src pytest -q`
- ❌ `pip install flake8` *(fails: Could not connect to proxy)*
- ❌ `tox -e py310` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685506f933388322848e77924302e657