### PR TITLE
Fix CLI import in processpipe

### DIFF
--- a/processpipe/__init__.py
+++ b/processpipe/__init__.py
@@ -1,6 +1,11 @@
 from . import processpipe_pkg as _pkg
 
-from .processpipe_pkg import cli
-
 __all__ = list(_pkg.__all__) + ["cli"]
 globals().update({k: getattr(_pkg, k) for k in _pkg.__all__})
+
+def __getattr__(name):
+    if name == "cli":
+        from .processpipe_pkg import cli
+        return cli
+    raise AttributeError(f"module {__name__} has no attribute {name}")
+

--- a/src/data_transformer_pipe/pipe.py
+++ b/src/data_transformer_pipe/pipe.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Dict, List, Union
 
 import pandas as pd
-import logging
-
 
 log = logging.getLogger("processpipe")
 

--- a/src/data_transformer_pipe/pipe.py
+++ b/src/data_transformer_pipe/pipe.py
@@ -26,7 +26,9 @@ class Operator:
             if name not in env:
                 raise KeyError(f"{self.__class__.__name__}: missing '{name}'")
         result = self._execute_core(env)
-        log.info("%s -> '%s' shape=%s", self.__class__.__name__, self.output, result.shape)
+        log.info(
+            "%s -> '%s' shape=%s", self.__class__.__name__, self.output, result.shape
+        )
         return result
 
 
@@ -64,7 +66,9 @@ class UnionOperator(Operator):
 
 
 class FilterOperator(Operator):
-    def __init__(self, source: str, predicate: str, *, output: str | None = None) -> None:
+    def __init__(
+        self, source: str, predicate: str, *, output: str | None = None
+    ) -> None:
         super().__init__(output or f"{source}_filtered")
         self.source = source
         self.predicate = predicate


### PR DESCRIPTION
## Summary
- avoid importing CLI at module import

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'data_transformer_pipe')*
- `tox -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68550aa79e6c8322a319e00705ce5c86