### PR TITLE
Implement CLI entry point and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,13 @@ After installing the package, you can run a pipeline directly from the command l
 3. Execute the plan and save the result:
 
    ```bash
-   data-transformer-pipe plan.json -o result.csv
+   pp run plan.json -o result.csv
+   ```
+
+   You can inspect the execution order without running it:
+
+   ```bash
+   pp dag plan.json
    ```
 
    The resulting `result.csv` will contain the joined rows.

--- a/processpipe/__main__.py
+++ b/processpipe/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/processpipe/cli/__init__.py
+++ b/processpipe/cli/__init__.py
@@ -1,0 +1,4 @@
+"""Command line interface entry point."""
+from ..processpipe_pkg.cli import main
+
+__all__ = ["main"]

--- a/src/data_transformer_pipe/pipe.py
+++ b/src/data_transformer_pipe/pipe.py
@@ -93,7 +93,7 @@ class AggregationOperator(Operator):
         self.inputs = [source]
 
     def _execute_core(self, env: Dict[str, pd.DataFrame]) -> pd.DataFrame:
-        return env[self.source].groupby(self.groupby).agg(self.agg_map).reset_index()
+        return env[self.source].groupby(self.groupby).agg(self.agg_map).reset_index()  # type: ignore[attr-defined]
 
 
 class GroupSizeOperator(Operator):
@@ -104,7 +104,7 @@ class GroupSizeOperator(Operator):
         self.inputs = [source]
 
     def _execute_core(self, env: Dict[str, pd.DataFrame]) -> pd.DataFrame:
-        df = env[self.source].copy()
+        df = env[self.source].copy()  # type: ignore[attr-defined]
         counts = df[self.groupby].value_counts()
         df["group_size"] = df[self.groupby].map(counts)
         return df

--- a/src/data_transformer_pipe/pipe.py
+++ b/src/data_transformer_pipe/pipe.py
@@ -93,7 +93,9 @@ class AggregationOperator(Operator):
         self.inputs = [source]
 
     def _execute_core(self, env: Dict[str, pd.DataFrame]) -> pd.DataFrame:
-        return env[self.source].groupby(self.groupby).agg(self.agg_map).reset_index()  # type: ignore[attr-defined]
+        grouped = env[self.source].groupby(self.groupby)
+        result = grouped.agg(self.agg_map).reset_index()  # type: ignore[attr-defined]
+        return result
 
 
 class GroupSizeOperator(Operator):

--- a/tests_processpipe/test_cli.py
+++ b/tests_processpipe/test_cli.py
@@ -1,0 +1,51 @@
+import json
+import subprocess
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from processpipe.cli import main
+
+
+def _create_plan(tmp_path: Path) -> Path:
+    plan = {
+        "dataframes": {
+            "df1": {"id": [1], "v": ["A"]},
+            "df2": {"id": [1], "v2": ["B"]},
+        },
+        "operations": [
+            {"type": "join", "left": "df1", "right": "df2", "on": "id", "output": "j"}
+        ],
+    }
+    path = tmp_path / "plan.json"
+    path.write_text(json.dumps(plan))
+    return path
+
+
+def test_cli_run(tmp_path):
+    plan_path = _create_plan(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(main, ["run", str(plan_path)])
+    assert result.exit_code == 0
+    assert "DataFrame" in result.output
+
+
+def test_cli_dag(tmp_path):
+    plan_path = _create_plan(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(main, ["dag", str(plan_path)])
+    assert result.exit_code == 0
+    assert "JoinOperator" in result.output
+
+
+def test_python_module_entrypoint(tmp_path):
+    plan_path = _create_plan(tmp_path)
+    res = subprocess.run([
+        "python",
+        "-m",
+        "processpipe",
+        "run",
+        str(plan_path),
+    ], capture_output=True, text=True)
+    assert res.returncode == 0
+    assert "DataFrame" in res.stdout


### PR DESCRIPTION
## Summary
- expose command line interface in `processpipe.cli`
- allow `python -m processpipe` to run the CLI
- document `pp` usage in README
- add unit tests for the CLI

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855111228408322bdd3238d20eb4770