### PR TITLE
Fix average score computation

### DIFF
--- a/examples/join_union_example.py
+++ b/examples/join_union_example.py
@@ -35,7 +35,8 @@ def main() -> None:
     print("Pipeline result:\n", result, "\n")
 
     # Simple analysis: average score, ignoring missing values
-    avg_score = result["score"].astype(float).mean()
+    scores = [float(v) for v in result["score"] if v is not None]
+    avg_score = sum(scores) / len(scores) if scores else None
     print("Average score:", avg_score)
 
 


### PR DESCRIPTION
## Summary
- update `join_union_example` to avoid pandas-specific `astype`

## Testing
- `PYTHONPATH=src:processpipe pytest -q`
- `PYTHONPATH=. python examples/join_union_example.py`

------
https://chatgpt.com/codex/tasks/task_e_6855532f9c408322a1f02c0c4729a8ed