### PR TITLE
Fix CLI help and ensure YAML support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ result = pipe.run()
 
 **Quick Start (CLI)**
 After installing the package, you can run a pipeline directly from the command line.
+Run `pp --help` to see available subcommands.
 
 1. Create input CSV files `df1.csv` and `df2.csv`:
 

--- a/click/__init__.py
+++ b/click/__init__.py
@@ -8,7 +8,14 @@ from functools import wraps
 def command():
     """Decorator to mark a function as a command."""
     def decorator(func):
-        return func
+        @wraps(func)
+        def wrapper(*args):
+            if args and args[0] in {"--help", "-h"}:
+                echo(func.__doc__ or "")
+                return
+            return func(*args)
+
+        return wrapper
     return decorator
 
 
@@ -28,13 +35,20 @@ def group():
         def wrapper(args=None):
             if args is None:
                 args = sys.argv[1:]
-            if args:
-                cmd_name = args[0]
-                cmd = commands.get(cmd_name)
-                if cmd is None:
-                    raise SystemExit(1)
-                return cmd(*args[1:])
-            return func()
+            if not args or args[0] in {"-h", "--help"}:
+                echo("Usage: [COMMAND]")
+                echo("Commands:")
+                for name in commands:
+                    echo(f"  {name}")
+                return
+            cmd_name = args[0]
+            cmd = commands.get(cmd_name)
+            if cmd is None:
+                raise SystemExit(1)
+            if len(args) > 1 and args[1] in {"-h", "--help"}:
+                echo(cmd.__doc__ or "")
+                return
+            return cmd(*args[1:])
 
         def add_command(cmd, name=None):
             commands[name or cmd.__name__] = cmd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ authors = [
 ]
 dependencies = [
     "click>=8.1",
+    "PyYAML>=6",
 ]
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary
- add `PyYAML` to project dependencies so YAML plans load correctly
- implement `--help` handling in the internal `click` stub
- mention `pp --help` in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685698fbf1208322bbf44fe2859ca343