### PR TITLE
Add integration test for ProcessPipe operator chain

### DIFF
--- a/tests_processpipe/test_integration_flow.py
+++ b/tests_processpipe/test_integration_flow.py
@@ -1,0 +1,43 @@
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+from processpipe import ProcessPipe
+
+
+def test_full_operator_chain():
+    customers = pd.DataFrame({"cust_id": [1, 2, 3], "region": ["east", "west", "east"]})
+    orders = pd.DataFrame(
+        {
+            "order_id": [1, 2, 3, 4, 5],
+            "cust_id": [1, 1, 2, 2, 3],
+            "amount": [120, 30, 200, 50, 80],
+        }
+    )
+    extra = pd.DataFrame({"region": ["north"], "amount": [0], "group_size": [0]})
+
+    pipe = (
+        ProcessPipe()
+        .add_dataframe("customers", customers)
+        .add_dataframe("orders", orders)
+        .add_dataframe("extra", extra)
+        .join("orders", "customers", on="cust_id", output="orders_cust")
+        .filter("orders_cust", predicate="amount > 100", output="big_orders")
+        .group_size("big_orders", groupby="cust_id", output="big_orders_count")
+        .aggregate(
+            "big_orders_count",
+            groupby="region",
+            agg_map={"amount": "sum", "group_size": "sum"},
+            output="region_totals",
+        )
+        .union("region_totals", "extra", output="all_regions")
+    )
+
+    result = pipe.run().reset_index(drop=True)
+    expected = pd.DataFrame(
+        {
+            "region": ["east", "west", "north"],
+            "amount": [120, 200, 0],
+            "group_size": [1, 1, 0],
+        }
+    )
+    assert_frame_equal(result, expected)


### PR DESCRIPTION
## Summary
- add integration test chaining join, filter, group_size, aggregate, and union

## Testing
- `make fmt` *(fails: No rule to make target)*
- `make lint` *(fails: No rule to make target)*
- `make test` *(fails: No rule to make target)*
- `ruff check tests_processpipe/test_integration_flow.py`
- `black tests_processpipe/test_integration_flow.py`
- `PYTHONPATH=$PWD/src:$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e1110391083228c21b528f6a1f5ca