### PR TITLE
Add support for conditional joins

### DIFF
--- a/processpipe/processpipe_pkg/core/pipe.py
+++ b/processpipe/processpipe_pkg/core/pipe.py
@@ -65,9 +65,17 @@ class ProcessPipe:
         return self
 
     # ── fluent operator helpers ───────────────────────────────────
-    def join(self, left: str, right: str, *, on, how="left",
-             output=None) -> "ProcessPipe":
-        return self._append(JoinOperator(left, right, on, how, output))
+    def join(
+        self,
+        left: str,
+        right: str,
+        *,
+        on,
+        how="left",
+        conditions=None,
+        output=None,
+    ) -> "ProcessPipe":
+        return self._append(JoinOperator(left, right, on, how, conditions, output))
 
     def union(self, left: str, right: str, *, output=None) -> "ProcessPipe":
         return self._append(UnionOperator(left, right, output=output))
@@ -141,6 +149,7 @@ class ProcessPipe:
                     op["right"],
                     on=op["on"],
                     how=op.get("how", "left"),
+                    conditions=op.get("conditions"),
                     output=op.get("output"),
                 )
             elif op_type == "union":

--- a/processpipe/processpipe_pkg/operators/join.py
+++ b/processpipe/processpipe_pkg/operators/join.py
@@ -1,19 +1,72 @@
 from __future__ import annotations
 
-from typing import List, Union, Dict
+from typing import List, Union, Dict, Tuple
 import pandas as pd
 from .base import Operator
 from ..core.backend import FrameBackend
 
 
 class JoinOperator(Operator):
-    def __init__(self, left: str, right: str, on: Union[str, List[str]],
-                 how: str = "left", output: str | None = None):
+    def __init__(
+        self,
+        left: str,
+        right: str,
+        on: Union[str, List[str]],
+        how: str = "left",
+        conditions: List[Tuple[str, str, str]] | None = None,
+        output: str | None = None,
+    ):
         super().__init__(output or f"{left}_{how}_join_{right}")
         self.left, self.right, self.on, self.how = left, right, on, how
+        self.conditions = conditions or []
         self.inputs = [left, right]
 
     def _execute_core(self, backend: FrameBackend,
                       env: Dict[str, pd.DataFrame]) -> pd.DataFrame:
-        return backend.merge(env[self.left], env[self.right],
-                             on=self.on, how=self.how)
+        left_df = env[self.left]
+        right_df = env[self.right]
+
+        if isinstance(self.on, str):
+            on_cols = [self.on]
+        else:
+            on_cols = list(self.on)
+
+        dup_cols = (
+            set(left_df.columns) & set(right_df.columns) - set(on_cols)
+        )
+
+        def _rename(df, suffix):
+            rows = []
+            for row in df._rows:
+                new_row = {}
+                for k, v in row.items():
+                    if k in on_cols:
+                        new_row[k] = v
+                    elif k in dup_cols:
+                        new_row[f"{k}{suffix}"] = v
+                    else:
+                        new_row[k] = v
+                rows.append(new_row)
+            if hasattr(pd.DataFrame, "from_rows"):
+                return pd.DataFrame.from_rows(rows)
+            cols: Dict[str, List] = {}
+            for r in rows:
+                for k, v in r.items():
+                    cols.setdefault(k, []).append(v)
+            return pd.DataFrame(cols)
+
+        left_df = _rename(left_df, "_left")
+        right_df = _rename(right_df, "_right")
+
+        df = backend.merge(left_df, right_df, on=on_cols, how="left")
+        if self.how == "inner":
+            right_columns = [c for c in right_df.columns if c not in on_cols]
+            if right_columns:
+                cond = " and ".join(f"{c} is not None" for c in right_columns)
+                df = backend.query(df, cond)
+        if self.conditions:
+            expr_parts = [
+                f"{l}_left {op} {r}_right" for l, op, r in self.conditions
+            ]
+            df = backend.query(df, " and ".join(expr_parts))
+        return df

--- a/tests_processpipe/test_join_conditions.py
+++ b/tests_processpipe/test_join_conditions.py
@@ -1,0 +1,37 @@
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+from processpipe import ProcessPipe
+
+
+def test_join_with_conditions():
+    left = pd.DataFrame({"id": [1, 2, 3], "val": ["A", "B", "C"]})
+    right = pd.DataFrame({"id": [1, 2, 4], "val": ["X", "B", "D"], "score": [10, 20, 30]})
+
+    pipe = (
+        ProcessPipe()
+        .add_dataframe("left", left)
+        .add_dataframe("right", right)
+        .join(
+            "left",
+            "right",
+            on="id",
+            how="inner",
+            conditions=[("val", "!=", "val")],
+            output="joined",
+        )
+    )
+
+    result = pipe.run().reset_index(drop=True)
+
+    expected = pd.DataFrame(
+        {
+            "id": [1],
+            "val_left": ["A"],
+            "val_right": ["X"],
+            "score": [10],
+        }
+    )
+
+    assert_frame_equal(result, expected)
+


### PR DESCRIPTION
## Summary
- extend `JoinOperator` to allow multiple join conditions
- support `inner` joins via filtering when using the stub backend
- expose `conditions` argument in `ProcessPipe.join` and loader
- test join with inequality condition

## Testing
- `PYTHONPATH=$PWD:$PWD/src pytest -q tests_processpipe/test_join_conditions.py -vv`
- `PYTHONPATH=$PWD:$PWD/src pytest -q tests tests_processpipe`

------
https://chatgpt.com/codex/tasks/task_e_685e28a322dc8322a24866bae21f3f4e