### PR TITLE
Fix join operator to honor join type

### DIFF
--- a/processpipe/processpipe_pkg/operators/join.py
+++ b/processpipe/processpipe_pkg/operators/join.py
@@ -58,7 +58,7 @@ class JoinOperator(Operator):
         left_df = _rename(left_df, "_left")
         right_df = _rename(right_df, "_right")
 
-        df = backend.merge(left_df, right_df, on=on_cols, how="left")
+        df = backend.merge(left_df, right_df, on=on_cols, how=self.how)
         if self.how == "inner":
             right_columns = [c for c in right_df.columns if c not in on_cols]
             if right_columns:


### PR DESCRIPTION
## Summary
- respect the `how` parameter in `JoinOperator`

## Testing
- `PYTHONPATH=src python -m pytest tests -q`
- `PYTHONPATH=src:processpipe/processpipe_pkg python -m pytest tests_processpipe -q`


------
https://chatgpt.com/codex/tasks/task_e_685e2bcd03a883228a53d37d152b5b7d