### PR TITLE
Add JoinError validations to join operator

### DIFF
--- a/tests_processpipe/test_join_conditions.py
+++ b/tests_processpipe/test_join_conditions.py
@@ -1,12 +1,17 @@
 import pandas as pd
 from pandas.testing import assert_frame_equal
 
+import pytest
+
 from processpipe import ProcessPipe
+from processpipe.processpipe_pkg.operators.join import JoinError
 
 
 def test_join_with_conditions():
     left = pd.DataFrame({"id": [1, 2, 3], "val": ["A", "B", "C"]})
-    right = pd.DataFrame({"id": [1, 2, 4], "val": ["X", "B", "D"], "score": [10, 20, 30]})
+    right = pd.DataFrame(
+        {"id": [1, 2, 4], "val": ["X", "B", "D"], "score": [10, 20, 30]}
+    )
 
     pipe = (
         ProcessPipe()
@@ -17,7 +22,7 @@ def test_join_with_conditions():
             "right",
             on="id",
             how="inner",
-            conditions=[("val", "!=", "val")],
+            conditions=[("val", "neq", "val")],
             output="joined",
         )
     )
@@ -35,3 +40,28 @@ def test_join_with_conditions():
 
     assert_frame_equal(result, expected)
 
+
+def test_join_condition_length_mismatch():
+    df = pd.DataFrame({"id": [1]})
+    pipe = (
+        ProcessPipe()
+        .add_dataframe("l", df)
+        .add_dataframe("r", df)
+        .join("l", "r", on=["id"], conditions=[("id", "eq", "id"), ("id", "eq", "id")])
+    )
+    with pytest.raises(JoinError.param_conflict) as exc:
+        pipe.run()
+    assert exc.value.code == "length_mismatch"
+
+
+def test_join_condition_bad_operator():
+    df = pd.DataFrame({"id": [1]})
+    pipe = (
+        ProcessPipe()
+        .add_dataframe("l", df)
+        .add_dataframe("r", df)
+        .join("l", "r", on="id", conditions=[("id", "~~", "id")])
+    )
+    with pytest.raises(JoinError.param_conflict) as exc:
+        pipe.run()
+    assert exc.value.code == "bad_operator"


### PR DESCRIPTION
## Summary
- introduce `JoinError` hierarchy for join operator
- validate join conditions length and operators
- add tests for new failure cases

## Testing
- `ruff check processpipe/processpipe_pkg/operators/join.py tests_processpipe/test_join_conditions.py`
- `pytest -q tests_processpipe/test_join_conditions.py`

------
https://chatgpt.com/codex/tasks/task_e_685f7d66b94c832291b00f48bcb24b75