### PR TITLE
Adjust join default in build_pipe

### DIFF
--- a/processpipe/processpipe_pkg/core/pipe.py
+++ b/processpipe/processpipe_pkg/core/pipe.py
@@ -35,8 +35,9 @@ from .backend import FrameBackend, InMemoryBackend
 
 log = logging.getLogger("processpipe")
 if not log.handlers:
-    logging.basicConfig(format="%(levelname)s %(name)s: %(message)s",
-                        level=logging.INFO)
+    logging.basicConfig(
+        format="%(levelname)s %(name)s: %(message)s", level=logging.INFO
+    )
 
 
 class ProcessPipe:
@@ -80,10 +81,10 @@ class ProcessPipe:
     def union(self, left: str, right: str, *, output=None) -> "ProcessPipe":
         return self._append(UnionOperator(left, right, output=output))
 
-    def aggregate(self, source: str, *, groupby, agg_map,
-                  output=None) -> "ProcessPipe":
-        return self._append(AggregationOperator(source, groupby, agg_map,
-                                                output=output))
+    def aggregate(self, source: str, *, groupby, agg_map, output=None) -> "ProcessPipe":
+        return self._append(
+            AggregationOperator(source, groupby, agg_map, output=output)
+        )
 
     def group_size(self, source: str, *, groupby, output=None) -> "ProcessPipe":
         return self._append(GroupSizeOperator(source, groupby, output=output))
@@ -91,16 +92,42 @@ class ProcessPipe:
     def filter(self, source: str, *, predicate, output=None) -> "ProcessPipe":
         return self._append(FilterOperator(source, predicate, output=output))
 
-    def rolling_agg(self, source: str, *, on, window, agg, output=None) -> "ProcessPipe":
+    def rolling_agg(
+        self, source: str, *, on, window, agg, output=None
+    ) -> "ProcessPipe":
         return self._append(RollingAggOperator(source, on, window, agg, output=output))
 
     def sort(self, source: str, *, by, ascending=True, output=None) -> "ProcessPipe":
-        return self._append(SortOperator(source, by, ascending=ascending, output=output))
+        return self._append(
+            SortOperator(source, by, ascending=ascending, output=output)
+        )
 
-    def top_n(self, source: str, *, n, metric, largest=True, per_group=False, group_keys=None, output=None) -> "ProcessPipe":
-        return self._append(TopNOperator(source, n, metric, largest=largest, per_group=per_group, group_keys=group_keys, output=output))
+    def top_n(
+        self,
+        source: str,
+        *,
+        n,
+        metric,
+        largest=True,
+        per_group=False,
+        group_keys=None,
+        output=None,
+    ) -> "ProcessPipe":
+        return self._append(
+            TopNOperator(
+                source,
+                n,
+                metric,
+                largest=largest,
+                per_group=per_group,
+                group_keys=group_keys,
+                output=output,
+            )
+        )
 
-    def fill_na(self, source: str, *, value, columns=None, output=None) -> "ProcessPipe":
+    def fill_na(
+        self, source: str, *, value, columns=None, output=None
+    ) -> "ProcessPipe":
         return self._append(FillNAOperator(source, value, columns, output=output))
 
     def rename(self, source: str, *, columns, output=None) -> "ProcessPipe":
@@ -109,17 +136,49 @@ class ProcessPipe:
     def cast(self, source: str, *, casts, output=None) -> "ProcessPipe":
         return self._append(CastOperator(source, casts, output=output))
 
-    def string_op(self, source: str, *, column, op, pattern, replacement=None, new_column=None, output=None) -> "ProcessPipe":
-        return self._append(StringOperator(source, column, op, pattern, replacement, output=output, new_column=new_column))
+    def string_op(
+        self,
+        source: str,
+        *,
+        column,
+        op,
+        pattern,
+        replacement=None,
+        new_column=None,
+        output=None,
+    ) -> "ProcessPipe":
+        return self._append(
+            StringOperator(
+                source,
+                column,
+                op,
+                pattern,
+                replacement,
+                output=output,
+                new_column=new_column,
+            )
+        )
 
-    def drop_duplicates(self, source: str, *, subset=None, keep="first", output=None) -> "ProcessPipe":
-        return self._append(DropDuplicateOperator(source, subset, keep=keep, output=output))
+    def drop_duplicates(
+        self, source: str, *, subset=None, keep="first", output=None
+    ) -> "ProcessPipe":
+        return self._append(
+            DropDuplicateOperator(source, subset, keep=keep, output=output)
+        )
 
-    def partition_agg(self, source: str, *, groupby, agg_map, output=None) -> "ProcessPipe":
-        return self._append(PartitionAggOperator(source, groupby, agg_map, output=output))
+    def partition_agg(
+        self, source: str, *, groupby, agg_map, output=None
+    ) -> "ProcessPipe":
+        return self._append(
+            PartitionAggOperator(source, groupby, agg_map, output=output)
+        )
 
-    def row_number(self, source: str, *, partition_by=None, order_by=None, output=None) -> "ProcessPipe":
-        return self._append(RowNumberOperator(source, partition_by, order_by, output=output))
+    def row_number(
+        self, source: str, *, partition_by=None, order_by=None, output=None
+    ) -> "ProcessPipe":
+        return self._append(
+            RowNumberOperator(source, partition_by, order_by, output=output)
+        )
 
     def delete(self, source: str, *, condition, output=None) -> "ProcessPipe":
         return self._append(DeleteOperator(source, condition, output=output))
@@ -127,8 +186,21 @@ class ProcessPipe:
     def update(self, source: str, *, condition, set_map, output=None) -> "ProcessPipe":
         return self._append(UpdateOperator(source, condition, set_map, output=output))
 
-    def case(self, source: str, *, conditions, choices, default=None, output_col="case", output=None) -> "ProcessPipe":
-        return self._append(CaseOperator(source, conditions, choices, default, output_col, output=output))
+    def case(
+        self,
+        source: str,
+        *,
+        conditions,
+        choices,
+        default=None,
+        output_col="case",
+        output=None,
+    ) -> "ProcessPipe":
+        return self._append(
+            CaseOperator(
+                source, conditions, choices, default, output_col, output=output
+            )
+        )
 
     # ── plan helpers ─────────────────────────────────────────────
     @classmethod
@@ -148,7 +220,7 @@ class ProcessPipe:
                     op["left"],
                     op["right"],
                     on=op["on"],
-                    how=op.get("how", "left"),
+                    how=op.get("how", "inner"),
                     conditions=op.get("conditions"),
                     output=op.get("output"),
                 )
@@ -308,7 +380,9 @@ class ProcessPipe:
             ops = level_ops[lvl]
             if self.max_workers > 1 and len(ops) > 1:
                 with ThreadPoolExecutor(max_workers=self.max_workers) as ex:
-                    futures = {ex.submit(op.execute, self.backend, self.env): op for op in ops}
+                    futures = {
+                        ex.submit(op.execute, self.backend, self.env): op for op in ops
+                    }
                     for fut, op in futures.items():
                         res = fut.result()
                         self.env[op.output] = res
@@ -319,7 +393,11 @@ class ProcessPipe:
 
         if self.max_workers > 1 or not isinstance(self.backend, InMemoryBackend):
             lineage = [
-                {"operator": op.__class__.__name__, "output": op.output, "inputs": op.inputs}
+                {
+                    "operator": op.__class__.__name__,
+                    "output": op.output,
+                    "inputs": op.inputs,
+                }
                 for op in self.ops
             ]
             with open("pipeline_run.json", "w") as f:

--- a/tests_processpipe/test_build_pipe_defaults.py
+++ b/tests_processpipe/test_build_pipe_defaults.py
@@ -1,0 +1,26 @@
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+from processpipe import ProcessPipe
+
+
+def test_build_pipe_join_default_inner():
+    plan = {
+        "dataframes": {
+            "df1": pd.DataFrame({"id": [1, 2], "val1": ["A", "B"]}),
+            "df2": pd.DataFrame({"id": [2], "val2": ["X"]}),
+        },
+        "operations": [
+            {
+                "type": "join",
+                "left": "df1",
+                "right": "df2",
+                "on": "id",
+                "output": "joined",
+            }
+        ],
+    }
+    pipe = ProcessPipe.build_pipe(plan)
+    result = pipe.run().reset_index(drop=True)
+    expected = pd.DataFrame({"id": [2], "val1": ["B"], "val2": ["X"]})
+    assert_frame_equal(result, expected)


### PR DESCRIPTION
## Summary
- use `inner` join by default when loading plans
- test that `build_pipe` falls back to inner join

## Testing
- `PYTHONPATH=.:src pytest -q tests tests_processpipe`

------
https://chatgpt.com/codex/tasks/task_e_685f7d6dd3608322964d6f783427d312